### PR TITLE
Add XFail and XPass to output string

### DIFF
--- a/pytest_slack/plugin.py
+++ b/pytest_slack/plugin.py
@@ -89,6 +89,8 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     passed = len(terminalreporter.stats.get('passed', []))
     skipped = len(terminalreporter.stats.get('skipped', []))
     error = len(terminalreporter.stats.get('error', []))
+    xfailed = len(terminalreporter.stats.get("xfailed", []))
+    xpassed = len(terminalreporter.stats.get("xpassed", []))
 
     report_link = config.option.slack_report_link
     slack_hook = config.option.slack_hook
@@ -105,7 +107,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         emoji = config.option.slack_failed_emoji
         icon = config.option.slack_failed_icon
 
-    final_results = 'Passed=%s Failed=%s Skipped=%s Error=%s' % (passed, failed, skipped, error)
+    final_results = 'Passed=%s Failed=%s Skipped=%s Error=%s XFailed=%s XPassed=%s' % (passed, failed, skipped, error, xfailed, xpassed)
     if report_link:
         final_results = '<%s|%s>' % (report_link, final_results)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -25,6 +25,15 @@ def test_pytest_slack_failed(testdir):
 
         def test_error(test):
             assert 1 == ""
+
+
+        @pytest.mark.xfail()
+        def test_xfail():
+            assert 1 == 2
+
+        @pytest.mark.xfail()
+        def test_xpass():
+            assert 1 == 1
         """
     )
 
@@ -33,7 +42,7 @@ def test_pytest_slack_failed(testdir):
     slack_hook_report_host = 'http://report_link.com'
     slack_hook_channel = 'test'
     slack_hook_icon_emoji = ':thumbsdown:'
-    expected_text = '<http://report_link.com|Passed=1 Failed=1 Skipped=1 Error=1>'
+    expected_text = '<http://report_link.com|Passed=1 Failed=1 Skipped=1 Error=1 XFailed=1 XPassed=1>'
     with mock.patch('requests.post') as mock_post:
         testdir.runpytest('--slack_channel', slack_hook_channel,
                           '--slack_hook', slack_hook_host,
@@ -74,7 +83,7 @@ def test_pytest_slack_passed(testdir):
     slack_hook_report_host = 'http://report_link.com'
     slack_hook_channel = 'test'
     slack_hook_icon_emoji = ':thumbsup:'
-    expected_text = '<http://report_link.com|Passed=1 Failed=0 Skipped=0 Error=0>'
+    expected_text = '<http://report_link.com|Passed=1 Failed=0 Skipped=0 Error=0 XFailed=0 XPassed=0>'
     with mock.patch('requests.post') as mock_post:
         testdir.runpytest('--slack_channel', slack_hook_channel,
                           '--slack_hook', slack_hook_host,


### PR DESCRIPTION
This change adds the XFail and XPass results to the slack message.