### PR TITLE
Fix flake8 lint errors

### DIFF
--- a/pytest_slack/plugin.py
+++ b/pytest_slack/plugin.py
@@ -107,7 +107,8 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         emoji = config.option.slack_failed_emoji
         icon = config.option.slack_failed_icon
 
-    final_results = 'Passed=%s Failed=%s Skipped=%s Error=%s XFailed=%s XPassed=%s' % (passed, failed, skipped, error, xfailed, xpassed)
+    final_results = 'Passed=%s Failed=%s Skipped=%s Error=%s XFailed=%s XPassed=%s' % (
+        passed, failed, skipped, error, xfailed, xpassed)
     if report_link:
         final_results = '<%s|%s>' % (report_link, final_results)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -194,4 +194,4 @@ def test_pytest_slack_icon_overrides_emoji(testdir, test_input, expected_url):
         emoji = called_data['icon_emoji']
 
         assert url == expected_url
-        assert emoji == None
+        assert emoji is None


### PR DESCRIPTION
I got the following errors when executing flake8 3.7.9 at Python 3.8:

```
$ flake8 pytest_slack tests
pytest_slack/plugin.py:110:121: E501 line too long (136 > 120 characters)
tests/test_plugin.py:197:22: E711 comparison to None should be 'if cond is None:'
1     E501 line too long (136 > 120 characters)
1     E711 comparison to None should be 'if cond is None:'
```
