### PR TITLE
Allow execution without --slack_channel option

### DIFF
--- a/pytest_slack/plugin.py
+++ b/pytest_slack/plugin.py
@@ -82,7 +82,7 @@ def pytest_addoption(parser):
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     yield
 
-    if not config.option.slack_hook or not config.option.slack_channel:
+    if not config.option.slack_hook:
         return
     timeout = config.option.slack_timeout
     failed = len(terminalreporter.stats.get('failed', []))


### PR DESCRIPTION
You can post messages to channel via Slack API without channel specification since an incoming webhook URL include a channel to default to post.
It would be useful if `pytest-slack` can be executed without `--slack_channel` option in case of unnecessary to change a post channel from the default.
