### PR TITLE
Add slack test name option 

### DIFF
--- a/pytest_messenger/slack.py
+++ b/pytest_messenger/slack.py
@@ -26,6 +26,13 @@ def add_slack_options(parser):
         default=None,
         help='Used for reporting to slack'
     )
+    group.addoption(
+        '--slack_test_name',
+        action='store',
+        dest='slack_test_name',
+        default=None,
+        help='Used for adding test name to the final report'
+    )
 
     group.addoption(
         '--slack_report_link',
@@ -104,6 +111,7 @@ def slack_send_message(test_result, config, exitstatus):
     timeout = config.option.slack_timeout
     report_link = config.option.slack_report_link
     only_failed = config.option.only_failed
+    slack_test_name = config.option.slack_test_name
     slack_hook = config.option.slack_hook
     channel = config.option.slack_channel
     ssl_verify = config.option.ssl_verify
@@ -133,10 +141,13 @@ def slack_send_message(test_result, config, exitstatus):
             test_result.error,
             test_result.xfailed,
             test_result.xpassed)
+    if slack_test_name:
+        final_results = 'Test=%s ' % (slack_test_name) + final_results
     if report_link:
         final_results = '<%s|%s>' % (report_link, final_results)
     if message_prefix:
         final_results = '%s: %s' % (message_prefix, final_results)
+    
     results_pattern = {
         "color": color,
         "text": final_results,

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -106,7 +106,6 @@ def test_pytest_messenger_slack_passed(testdir):
         assert color == '#56a64f'
         assert emoji == slack_hook_icon_emoji
 
-
 @pytest.mark.parametrize('expected_prefix,report_link', [
     ("Test Prefix", None),
     ("Test Prefix", "http://report_link.com")
@@ -136,6 +135,43 @@ def test_pytest_messenger_slack_message_prefix(testdir, expected_prefix, report_
     if report_link:
         expected_text = '<%s|%s>' % (report_link, expected_text)
     expected_text = '%s: %s' % (expected_prefix, expected_text)
+
+    with mock.patch('requests.post') as mock_post:
+        testdir.runpytest(*run_args)
+
+        called_data = json.loads(mock_post.call_args[1]['data'])
+        text = called_data['attachments'][0]['text']
+
+        assert text == expected_text
+
+@pytest.mark.parametrize('expected_test_name,report_link', [
+    ("test_name", None),
+    ("test_name", "http://report_link.com")
+])
+def test_pytest_messenger_slack_message_test_name(testdir, expected_test_name, report_link):
+    """Make sure that message test_name works."""
+
+    testdir.makepyfile(
+        """
+        import pytest
+        def test_pass():
+            assert 1 == 1
+        """
+    )
+
+    slack_hook_host = 'http://test.com/any_hash'
+    slack_hook_channel = 'test'
+    run_args = [
+        '--slack_channel', slack_hook_channel,
+        '--slack_hook', slack_hook_host,
+        '--slack_test_name', expected_test_name
+    ]
+    if report_link:
+        run_args.extend(['--slack_report_link', report_link])
+
+    expected_text = 'Test=test_name Passed=1 Failed=0 Skipped=0 Error=0 XFailed=0 XPassed=0'
+    if report_link:
+        expected_text = '<%s|%s>' % (report_link, expected_text)
 
     with mock.patch('requests.post') as mock_post:
         testdir.runpytest(*run_args)


### PR DESCRIPTION
### What
As the recent version of slack does not allow sending --slack_username this will work as a kind of replacement for that feature
https://github.com/pytest-dev/pytest-messenger/issues/125

## Testing
Added a new test to cover the case 